### PR TITLE
chore: harmonize API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Application-wide theming with component-level isolation for styled-components.
 
 ## Status
 
-| Category         | Status                                                                                                      |
-| ---------------- | ----------------------------------------------------------------------------------------------------------- |
-| Version          | [![npm](https://img.shields.io/npm/v/@nhummel/styled-components-theming)](https://www.npmjs.com/package/@nhummel/styled-components-theming)     |
-| Build            | ![GitHub Actions](https://github.com/strangedev/styled-components-theming/workflows/Release/badge.svg?branch=main) |
-| License          | ![GitHub](https://img.shields.io/github/license/strangedev/styled-components-theming)                              |
+| Category | Status                                                                                                                                      |
+|----------|---------------------------------------------------------------------------------------------------------------------------------------------|
+| Version  | [![npm](https://img.shields.io/npm/v/@nhummel/styled-components-theming)](https://www.npmjs.com/package/@nhummel/styled-components-theming) |
+| Build    | ![GitHub Actions](https://github.com/strangedev/styled-components-theming/workflows/Release/badge.svg?branch=main)                          |
+| License  | ![GitHub](https://img.shields.io/github/license/strangedev/styled-components-theming)                                                       |
 
 ## Introduction
 
@@ -73,7 +73,7 @@ different values. You can implement a dark mode, or re-skin your application wit
 these.
 
 ```tsx
-const { globalThemeContext, GlobalThemeProvider, useTheme } = createGlobalThemeProvider({
+const { globalThemeContext, GlobalThemeProvider, useTheme } = createGlobalTheme({
   globalThemes: {
     dark: {
       space: (units: number): string => `${units * 4}px`,
@@ -110,7 +110,7 @@ correctly.
 
 ### Add the `GlobalThemeProvider` to your application
 
-In the example above, you can see that `createGlobalThemeProvider` returns a
+In the example above, you can see that `createGlobalTheme` returns a
 React component `GlobalThemeProvider`. You need to add this context provider to
 your application somewhere high up in the tree. All components using local themes
 must be below it.
@@ -136,7 +136,7 @@ export default App;
 
 You can now use `createLocalTheme` to create isolated component-level themes.
 To do that, you'll need to pass the `globalThemeContext` obtained from
-`createGlobalThemeProvider`.
+`createGlobalTheme`.
 
 ```tsx
 import { globalThemeContext } from './style/GlobalThemeProvider';
@@ -186,7 +186,7 @@ The `from` function receives the local theme as its only argument.
 
 ### Switching between variants & `useTheme`
 
-The call to `createGlobalThemeProvider` also returns a hook called `useTheme`.
+The call to `createGlobalTheme` also returns a hook called `useTheme`.
 This hook can be used to obtain information about variants, access the global theme
 directly, or switch the current variant.
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ these.
 
 ```tsx
 const { globalThemeContext, GlobalThemeProvider, useTheme } = createGlobalThemeProvider({
-  themes: {
+  globalThemes: {
     dark: {
       space: (units: number): string => `${units * 4}px`,
       brandColor: '#a5e',
@@ -143,9 +143,9 @@ import { globalThemeContext } from './style/GlobalThemeProvider';
 
 const { from } = createLocalTheme({
   globalThemeContext,
-  factory ({ theme, variant }) {
-    const { brandColor, background } = theme;
-    let { color } = theme;
+  factory ({ globalTheme, variant }) {
+    const { brandColor, background } = globalTheme;
+    let { color } = globalTheme;
 
     if (variant === 'light') {
       color = background;
@@ -154,14 +154,14 @@ const { from } = createLocalTheme({
     return {
       color,
       background: brandColor,
-      padding: theme.space(2)
+      padding: globalTheme.space(2)
     };
   }
 });
 ```
 
-The `factory` parameter is a function that receives the current theme and the
-name of the current variant and returns the local theme. The local theme can
+The `factory` parameter is a function that receives the current global theme and
+the name of the current variant and returns the local theme. The local theme can
 be an arbitrary object as well, but as a general rule it is best that the values
 are all either strings or have a `toString` method.
 
@@ -195,7 +195,7 @@ const ThemeSwitch: FunctionComponent = () => {
   const {
     availableVariants,
     variant,
-    theme,
+    globalTheme,
     switchVariant
   } = useTheme();
 

--- a/lib/GlobalThemeContext.ts
+++ b/lib/GlobalThemeContext.ts
@@ -1,35 +1,10 @@
-import React from 'react';
-
 interface GlobalThemeContext<TVariants, TGlobalTheme> {
-  theme: TGlobalTheme;
+  globalTheme: TGlobalTheme;
   variant: TVariants;
   availableVariants: TVariants[];
   switchVariant: (variant: TVariants) => void;
 }
 
-const getGlobalThemeContext = function <TVariants extends string, TGlobalTheme> ({
-  themes,
-  defaultVariant
-}: {
-  themes: Record<TVariants, TGlobalTheme>;
-  defaultVariant: TVariants;
-}): React.Context<GlobalThemeContext<TVariants, TGlobalTheme>> {
-  const state = {
-    theme: themes[defaultVariant],
-    variant: defaultVariant,
-    availableVariants: Object.keys(themes) as TVariants[],
-    switchVariant (variant: TVariants): void {
-      state.theme = themes[variant];
-      state.variant = variant;
-    }
-  };
-
-  return React.createContext<GlobalThemeContext<TVariants, TGlobalTheme>>(state);
-};
-
-export {
-  getGlobalThemeContext
-};
 export type {
   GlobalThemeContext
 };

--- a/lib/ThemeFactory.ts
+++ b/lib/ThemeFactory.ts
@@ -1,5 +1,5 @@
 interface ThemeFactoryArgs<TVariants, TGlobalTheme> {
-  theme: TGlobalTheme;
+  globalTheme: TGlobalTheme;
   variant: TVariants;
 }
 

--- a/lib/createGlobalTheme.tsx
+++ b/lib/createGlobalTheme.tsx
@@ -1,7 +1,7 @@
 import { GlobalThemeContext } from './GlobalThemeContext';
 import React, { Context, FunctionComponent, useContext, useState } from 'react';
 
-const createGlobalThemeProvider = function <TVariants extends string, TGlobalTheme> ({
+const createGlobalTheme = function <TVariants extends string, TGlobalTheme> ({
   globalThemes,
   defaultVariant
 }: {
@@ -45,5 +45,5 @@ const createGlobalThemeProvider = function <TVariants extends string, TGlobalThe
 };
 
 export {
-  createGlobalThemeProvider
+  createGlobalTheme
 };

--- a/lib/createGlobalThemeProvider.tsx
+++ b/lib/createGlobalThemeProvider.tsx
@@ -1,11 +1,11 @@
-import { getGlobalThemeContext, GlobalThemeContext } from './GlobalThemeContext';
+import { GlobalThemeContext } from './GlobalThemeContext';
 import React, { Context, FunctionComponent, useContext, useState } from 'react';
 
 const createGlobalThemeProvider = function <TVariants extends string, TGlobalTheme> ({
-  themes,
+  globalThemes,
   defaultVariant
 }: {
-  themes: Record<TVariants, TGlobalTheme>;
+  globalThemes: Record<TVariants, TGlobalTheme>;
   variants: readonly TVariants[];
   defaultVariant: TVariants;
 }): {
@@ -13,17 +13,17 @@ const createGlobalThemeProvider = function <TVariants extends string, TGlobalThe
     globalThemeContext: Context<GlobalThemeContext<TVariants, TGlobalTheme>>;
     useTheme: () => GlobalThemeContext<TVariants, TGlobalTheme>;
   } {
-  const globalThemeContext = getGlobalThemeContext({ themes, defaultVariant });
+  const globalThemeContext = React.createContext<GlobalThemeContext<TVariants, TGlobalTheme>>({} as any);
 
   const GlobalThemeProvider: FunctionComponent = ({ children }) => {
     const [ value, setValue ] = useState<GlobalThemeContext<TVariants, TGlobalTheme>>({
-      theme: themes[defaultVariant],
+      globalTheme: globalThemes[defaultVariant],
       variant: defaultVariant,
-      availableVariants: Object.keys(themes) as TVariants[],
+      availableVariants: Object.keys(globalThemes) as TVariants[],
       switchVariant (variant: TVariants): void {
         setValue({
           ...value,
-          theme: themes[variant],
+          globalTheme: globalThemes[variant],
           variant
         });
       }

--- a/lib/createLocalTheme.ts
+++ b/lib/createLocalTheme.ts
@@ -22,10 +22,10 @@ const createLocalTheme = function <TLocalTheme extends object, TGlobalThemeConte
   let renderedForVariant: InferVariants<TGlobalThemeContext> | null = null;
 
   const getLocalTheme = (): TLocalTheme => {
-    const { theme, variant } = useContext(globalThemeContext);
+    const { globalTheme, variant } = useContext(globalThemeContext);
 
     if (!localTheme || variant !== renderedForVariant) {
-      localTheme = factory({ theme, variant });
+      localTheme = factory({ globalTheme, variant });
       renderedForVariant = variant;
     }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,9 +1,9 @@
-import { createGlobalThemeProvider } from './createGlobalThemeProvider';
+import { createGlobalTheme } from './createGlobalTheme';
 import { createLocalTheme } from './createLocalTheme';
 import { ThemeFactory, ThemeFactoryArgs } from './ThemeFactory';
 
 export {
-  createGlobalThemeProvider,
+  createGlobalTheme,
   createLocalTheme
 };
 export type {

--- a/test/integration/componentTests.tsx
+++ b/test/integration/componentTests.tsx
@@ -6,7 +6,7 @@ import { Length, px } from '@nhummel/css-in-js';
 import React, { FunctionComponent } from 'react';
 
 const configuration = {
-  themes: {
+  globalThemes: {
     dark: {
       space: (units: number): Length => Length.new(units * 4, px),
       brandColor: '#a5e',
@@ -33,9 +33,9 @@ suite('Component tests', (): void => {
     const { globalThemeContext, GlobalThemeProvider } = createGlobalThemeProvider(configuration);
     const { from: fromOne } = createLocalTheme({
       globalThemeContext,
-      factory ({ theme, variant }) {
-        const { brandColor, background } = theme;
-        let { color } = theme;
+      factory ({ globalTheme, variant }) {
+        const { brandColor, background } = globalTheme;
+        let { color } = globalTheme;
 
         if (variant === 'light') {
           color = background;
@@ -44,7 +44,7 @@ suite('Component tests', (): void => {
         return {
           color,
           background: brandColor,
-          padding: theme.space(2)
+          padding: globalTheme.space(2)
         };
       }
     });
@@ -57,9 +57,9 @@ suite('Component tests', (): void => {
 
     const { from: fromTwo } = createLocalTheme({
       globalThemeContext,
-      factory ({ theme }) {
+      factory ({ globalTheme }) {
         return {
-          marginLeft: theme.space(16)
+          marginLeft: globalTheme.space(16)
         };
       }
     });
@@ -95,9 +95,9 @@ suite('Component tests', (): void => {
       const { globalThemeContext, GlobalThemeProvider, useTheme } = createGlobalThemeProvider(configuration);
       const { from } = createLocalTheme({
         globalThemeContext,
-        factory ({ theme, variant }) {
-          const { brandColor, background } = theme;
-          let { color } = theme;
+        factory ({ globalTheme, variant }) {
+          const { brandColor, background } = globalTheme;
+          let { color } = globalTheme;
 
           if (variant === 'light') {
             color = background;
@@ -106,7 +106,7 @@ suite('Component tests', (): void => {
           return {
             color,
             background: brandColor,
-            padding: theme.space(2)
+            padding: globalTheme.space(2)
           };
         }
       });
@@ -225,12 +225,12 @@ suite('Component tests', (): void => {
       const { GlobalThemeProvider, useTheme } = createGlobalThemeProvider(configuration);
 
       const Dummy: FunctionComponent = () => {
-        const { theme } = useTheme();
+        const { globalTheme } = useTheme();
 
         return (
           <div
             data-testid='value'
-            data-theme={ JSON.stringify(theme) }
+            data-theme={ JSON.stringify(globalTheme) }
           />
         );
       };
@@ -245,7 +245,7 @@ suite('Component tests', (): void => {
         const dummy = await screen.findByTestId('value');
         const actual = dummy.dataset.theme;
 
-        assert.that(actual).is.equalTo(JSON.stringify(configuration.themes[configuration.defaultVariant]));
+        assert.that(actual).is.equalTo(JSON.stringify(configuration.globalThemes[configuration.defaultVariant]));
       });
     });
   });
@@ -254,9 +254,9 @@ suite('Component tests', (): void => {
       const { globalThemeContext, GlobalThemeProvider } = createGlobalThemeProvider(configuration);
       const { from } = createLocalTheme({
         globalThemeContext,
-        factory ({ theme, variant }) {
-          const { brandColor, background } = theme;
-          let { color } = theme;
+        factory ({ globalTheme, variant }) {
+          const { brandColor, background } = globalTheme;
+          let { color } = globalTheme;
 
           if (variant === 'light') {
             color = background;
@@ -265,7 +265,7 @@ suite('Component tests', (): void => {
           return {
             color,
             background: brandColor,
-            padding: theme.space(2)
+            padding: globalTheme.space(2)
           };
         }
       });
@@ -292,14 +292,14 @@ suite('Component tests', (): void => {
         assert.that(bannerStyle.padding).is.equalTo('8px');
       });
     });
-    suite('get function', (): void => {
+    suite('from function', (): void => {
       test('allows access to values in the local theme.', async (): Promise<void> => {
         const { globalThemeContext, GlobalThemeProvider } = createGlobalThemeProvider(configuration);
         const { from } = createLocalTheme({
           globalThemeContext,
-          factory ({ theme, variant }) {
-            const { brandColor, background } = theme;
-            let { color } = theme;
+          factory ({ globalTheme, variant }) {
+            const { brandColor, background } = globalTheme;
+            let { color } = globalTheme;
 
             if (variant === 'light') {
               color = background;
@@ -308,7 +308,7 @@ suite('Component tests', (): void => {
             return {
               color,
               background: brandColor,
-              padding: theme.space(2)
+              padding: globalTheme.space(2)
             };
           }
         });
@@ -339,9 +339,9 @@ suite('Component tests', (): void => {
         const { globalThemeContext, GlobalThemeProvider } = createGlobalThemeProvider(configuration);
         const { from } = createLocalTheme({
           globalThemeContext,
-          factory ({ theme, variant }) {
-            const { brandColor, background, space } = theme;
-            let { color } = theme;
+          factory ({ globalTheme, variant }) {
+            const { brandColor, background, space } = globalTheme;
+            let { color } = globalTheme;
 
             if (variant === 'light') {
               color = background;

--- a/test/integration/componentTests.tsx
+++ b/test/integration/componentTests.tsx
@@ -1,7 +1,7 @@
 import { assert } from 'assertthat';
 import styled from 'styled-components';
 import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
-import { createGlobalThemeProvider, createLocalTheme } from '../../lib';
+import { createGlobalTheme, createLocalTheme } from '../../lib';
 import { Length, px } from '@nhummel/css-in-js';
 import React, { FunctionComponent } from 'react';
 
@@ -30,7 +30,7 @@ suite('Component tests', (): void => {
   });
 
   test('styles styled-components isolated from each other.', async (): Promise<void> => {
-    const { globalThemeContext, GlobalThemeProvider } = createGlobalThemeProvider(configuration);
+    const { globalThemeContext, GlobalThemeProvider } = createGlobalTheme(configuration);
     const { from: fromOne } = createLocalTheme({
       globalThemeContext,
       factory ({ globalTheme, variant }) {
@@ -92,7 +92,7 @@ suite('Component tests', (): void => {
   });
   suite('useTheme hook', (): void => {
     test('can be used to switch the variant, re-rendering the component.', async (): Promise<void> => {
-      const { globalThemeContext, GlobalThemeProvider, useTheme } = createGlobalThemeProvider(configuration);
+      const { globalThemeContext, GlobalThemeProvider, useTheme } = createGlobalTheme(configuration);
       const { from } = createLocalTheme({
         globalThemeContext,
         factory ({ globalTheme, variant }) {
@@ -168,7 +168,7 @@ suite('Component tests', (): void => {
       });
     });
     test('can be used to obtain the available variants.', async (): Promise<void> => {
-      const { GlobalThemeProvider, useTheme } = createGlobalThemeProvider(configuration);
+      const { GlobalThemeProvider, useTheme } = createGlobalTheme(configuration);
 
       const Dummy: FunctionComponent = () => {
         const { availableVariants } = useTheme();
@@ -195,7 +195,7 @@ suite('Component tests', (): void => {
       });
     });
     test('can be used to obtain the current variant.', async (): Promise<void> => {
-      const { GlobalThemeProvider, useTheme } = createGlobalThemeProvider(configuration);
+      const { GlobalThemeProvider, useTheme } = createGlobalTheme(configuration);
 
       const Dummy: FunctionComponent = () => {
         const { variant } = useTheme();
@@ -222,7 +222,7 @@ suite('Component tests', (): void => {
       });
     });
     test('can be used to access the global theme.', async (): Promise<void> => {
-      const { GlobalThemeProvider, useTheme } = createGlobalThemeProvider(configuration);
+      const { GlobalThemeProvider, useTheme } = createGlobalTheme(configuration);
 
       const Dummy: FunctionComponent = () => {
         const { globalTheme } = useTheme();
@@ -251,7 +251,7 @@ suite('Component tests', (): void => {
   });
   suite('createLocalTheme', (): void => {
     test('the theme factory can be a function with arbitrary logic.', async (): Promise<void> => {
-      const { globalThemeContext, GlobalThemeProvider } = createGlobalThemeProvider(configuration);
+      const { globalThemeContext, GlobalThemeProvider } = createGlobalTheme(configuration);
       const { from } = createLocalTheme({
         globalThemeContext,
         factory ({ globalTheme, variant }) {
@@ -294,7 +294,7 @@ suite('Component tests', (): void => {
     });
     suite('from function', (): void => {
       test('allows access to values in the local theme.', async (): Promise<void> => {
-        const { globalThemeContext, GlobalThemeProvider } = createGlobalThemeProvider(configuration);
+        const { globalThemeContext, GlobalThemeProvider } = createGlobalTheme(configuration);
         const { from } = createLocalTheme({
           globalThemeContext,
           factory ({ globalTheme, variant }) {
@@ -336,7 +336,7 @@ suite('Component tests', (): void => {
         });
       });
       test('allows access to functions in the local theme.', async (): Promise<void> => {
-        const { globalThemeContext, GlobalThemeProvider } = createGlobalThemeProvider(configuration);
+        const { globalThemeContext, GlobalThemeProvider } = createGlobalTheme(configuration);
         const { from } = createLocalTheme({
           globalThemeContext,
           factory ({ globalTheme, variant }) {


### PR DESCRIPTION
BREAKING CHANGES:

* To better distinguish between global and component level themes which were previously both called `theme`, the theme obtained by `useTheme` and passed to the `factory` parameter of `createLocalTheme` is now called `globalTheme`.
* Since `createGlobalThemeProvider` returns more than just a context provider and to harmonize the naming with `createLocalTheme`, `createGlobalThemeProvider` was renamed to `createGlobalTheme`.
* The themes parameters of `createGlobalTheme` was renamed to `globalThemes`.