### PR TITLE
feat: pass context implicitly to createLocalTheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ different values. You can implement a dark mode, or re-skin your application wit
 these.
 
 ```tsx
-const { globalThemeContext, GlobalThemeProvider, useTheme } = createGlobalTheme({
+const { createLocalTheme, GlobalThemeProvider, useTheme } = createGlobalTheme({
   globalThemes: {
     dark: {
       space: (units: number): string => `${units * 4}px`,
@@ -93,7 +93,7 @@ const { globalThemeContext, GlobalThemeProvider, useTheme } = createGlobalTheme(
 });
 
 export {
-  globalThemeContext,
+  createLocalTheme,
   GlobalThemeProvider,
   useTheme
 };
@@ -135,15 +135,12 @@ export default App;
 ### Create component-level themes
 
 You can now use `createLocalTheme` to create isolated component-level themes.
-To do that, you'll need to pass the `globalThemeContext` obtained from
-`createGlobalTheme`.
 
 ```tsx
 import { globalThemeContext } from './style/GlobalThemeProvider';
 
-const { from } = createLocalTheme({
-  globalThemeContext,
-  factory ({ globalTheme, variant }) {
+const { from } = createLocalTheme(
+  ({ globalTheme, variant }) => {
     const { brandColor, background } = globalTheme;
     let { color } = globalTheme;
 
@@ -157,17 +154,17 @@ const { from } = createLocalTheme({
       padding: globalTheme.space(2)
     };
   }
-});
+);
 ```
 
-The `factory` parameter is a function that receives the current global theme and
+The first parameter is a factory that receives the current global theme and
 the name of the current variant and returns the local theme. The local theme can
 be an arbitrary object as well, but as a general rule it is best that the values
 are all either strings or have a `toString` method.
 
-Note that you can execute logic in the `factory` and make decisions based on the
+Note that you can execute logic in the factory and make decisions based on the
 `variant`. While only the theme corresponding to the `variant` is passed to the
-`factory`, in some cases, you might want to switch things around.
+factory, in some cases, you might want to switch things around.
 
 ### Using the local theme
 

--- a/lib/ContextDependentFuture.ts
+++ b/lib/ContextDependentFuture.ts
@@ -1,0 +1,5 @@
+type ContextDependentFuture = () => string;
+
+export type {
+  ContextDependentFuture
+};

--- a/lib/FromFunction.ts
+++ b/lib/FromFunction.ts
@@ -1,0 +1,8 @@
+import { ContextDependentFuture } from './ContextDependentFuture';
+import { Getter } from './Getter';
+
+type FromFunction<TLocalTheme> = (getter: Getter<TLocalTheme>) => ContextDependentFuture;
+
+export type {
+  FromFunction
+};

--- a/lib/Getter.ts
+++ b/lib/Getter.ts
@@ -1,0 +1,7 @@
+import { Stringlike } from '@nhummel/css-in-js';
+
+type Getter<TLocalTheme> = (theme: TLocalTheme) => Stringlike;
+
+export type {
+  Getter
+};

--- a/lib/createGlobalTheme.tsx
+++ b/lib/createGlobalTheme.tsx
@@ -1,5 +1,6 @@
 import { GlobalThemeContext } from './GlobalThemeContext';
-import React, { Context, FunctionComponent, useContext, useState } from 'react';
+import { CreateLocalTheme, getCreateLocalTheme } from './createLocalTheme';
+import React, { FunctionComponent, useContext, useState } from 'react';
 
 const createGlobalTheme = function <TVariants extends string, TGlobalTheme> ({
   globalThemes,
@@ -10,10 +11,11 @@ const createGlobalTheme = function <TVariants extends string, TGlobalTheme> ({
   defaultVariant: TVariants;
 }): {
     GlobalThemeProvider: FunctionComponent;
-    globalThemeContext: Context<GlobalThemeContext<TVariants, TGlobalTheme>>;
     useTheme: () => GlobalThemeContext<TVariants, TGlobalTheme>;
+    createLocalTheme: CreateLocalTheme<TVariants, TGlobalTheme>;
   } {
   const globalThemeContext = React.createContext<GlobalThemeContext<TVariants, TGlobalTheme>>({} as any);
+  const createLocalTheme = getCreateLocalTheme(globalThemeContext);
 
   const GlobalThemeProvider: FunctionComponent = ({ children }) => {
     const [ value, setValue ] = useState<GlobalThemeContext<TVariants, TGlobalTheme>>({
@@ -39,8 +41,8 @@ const createGlobalTheme = function <TVariants extends string, TGlobalTheme> ({
 
   return {
     GlobalThemeProvider,
-    globalThemeContext,
-    useTheme: (): GlobalThemeContext<TVariants, TGlobalTheme> => useContext(globalThemeContext)
+    useTheme: (): GlobalThemeContext<TVariants, TGlobalTheme> => useContext(globalThemeContext),
+    createLocalTheme
   };
 };
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,10 +1,8 @@
 import { createGlobalTheme } from './createGlobalTheme';
-import { createLocalTheme } from './createLocalTheme';
 import { ThemeFactory, ThemeFactoryArgs } from './ThemeFactory';
 
 export {
-  createGlobalTheme,
-  createLocalTheme
+  createGlobalTheme
 };
 export type {
   ThemeFactory,

--- a/test/integration/componentTests.tsx
+++ b/test/integration/componentTests.tsx
@@ -1,7 +1,7 @@
 import { assert } from 'assertthat';
+import { createGlobalTheme } from '../../lib';
 import styled from 'styled-components';
 import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
-import { createGlobalTheme, createLocalTheme } from '../../lib';
 import { Length, px } from '@nhummel/css-in-js';
 import React, { FunctionComponent } from 'react';
 
@@ -30,10 +30,9 @@ suite('Component tests', (): void => {
   });
 
   test('styles styled-components isolated from each other.', async (): Promise<void> => {
-    const { globalThemeContext, GlobalThemeProvider } = createGlobalTheme(configuration);
-    const { from: fromOne } = createLocalTheme({
-      globalThemeContext,
-      factory ({ globalTheme, variant }) {
+    const { GlobalThemeProvider, createLocalTheme } = createGlobalTheme(configuration);
+    const { from: fromOne } = createLocalTheme(
+      ({ globalTheme, variant }) => {
         const { brandColor, background } = globalTheme;
         let { color } = globalTheme;
 
@@ -47,7 +46,7 @@ suite('Component tests', (): void => {
           padding: globalTheme.space(2)
         };
       }
-    });
+    );
 
     const Banner = styled.div`
       color: ${fromOne(theme => theme.color)};
@@ -55,14 +54,11 @@ suite('Component tests', (): void => {
       padding: ${fromOne(theme => theme.padding)};
     `;
 
-    const { from: fromTwo } = createLocalTheme({
-      globalThemeContext,
-      factory ({ globalTheme }) {
-        return {
-          marginLeft: globalTheme.space(16)
-        };
-      }
-    });
+    const { from: fromTwo } = createLocalTheme(
+      ({ globalTheme }) => ({
+        marginLeft: globalTheme.space(16)
+      })
+    );
 
     const Logo = styled.div`
       margin-left: ${fromTwo(theme => theme.marginLeft)};
@@ -92,10 +88,9 @@ suite('Component tests', (): void => {
   });
   suite('useTheme hook', (): void => {
     test('can be used to switch the variant, re-rendering the component.', async (): Promise<void> => {
-      const { globalThemeContext, GlobalThemeProvider, useTheme } = createGlobalTheme(configuration);
-      const { from } = createLocalTheme({
-        globalThemeContext,
-        factory ({ globalTheme, variant }) {
+      const { createLocalTheme, GlobalThemeProvider, useTheme } = createGlobalTheme(configuration);
+      const { from } = createLocalTheme(
+        ({ globalTheme, variant }) => {
           const { brandColor, background } = globalTheme;
           let { color } = globalTheme;
 
@@ -109,7 +104,7 @@ suite('Component tests', (): void => {
             padding: globalTheme.space(2)
           };
         }
-      });
+      );
 
       const Banner = styled.div`
         color: ${from(theme => theme.color)};
@@ -251,10 +246,9 @@ suite('Component tests', (): void => {
   });
   suite('createLocalTheme', (): void => {
     test('the theme factory can be a function with arbitrary logic.', async (): Promise<void> => {
-      const { globalThemeContext, GlobalThemeProvider } = createGlobalTheme(configuration);
-      const { from } = createLocalTheme({
-        globalThemeContext,
-        factory ({ globalTheme, variant }) {
+      const { GlobalThemeProvider, createLocalTheme } = createGlobalTheme(configuration);
+      const { from } = createLocalTheme(
+        ({ globalTheme, variant }) => {
           const { brandColor, background } = globalTheme;
           let { color } = globalTheme;
 
@@ -268,7 +262,7 @@ suite('Component tests', (): void => {
             padding: globalTheme.space(2)
           };
         }
-      });
+      );
 
       const Banner = styled.div`
         color: ${from(theme => theme.color)};
@@ -294,10 +288,9 @@ suite('Component tests', (): void => {
     });
     suite('from function', (): void => {
       test('allows access to values in the local theme.', async (): Promise<void> => {
-        const { globalThemeContext, GlobalThemeProvider } = createGlobalTheme(configuration);
-        const { from } = createLocalTheme({
-          globalThemeContext,
-          factory ({ globalTheme, variant }) {
+        const { GlobalThemeProvider, createLocalTheme } = createGlobalTheme(configuration);
+        const { from } = createLocalTheme(
+          ({ globalTheme, variant }) => {
             const { brandColor, background } = globalTheme;
             let { color } = globalTheme;
 
@@ -311,7 +304,7 @@ suite('Component tests', (): void => {
               padding: globalTheme.space(2)
             };
           }
-        });
+        );
 
         const Banner = styled.div`
           color: ${from(theme => theme.color)};
@@ -336,10 +329,9 @@ suite('Component tests', (): void => {
         });
       });
       test('allows access to functions in the local theme.', async (): Promise<void> => {
-        const { globalThemeContext, GlobalThemeProvider } = createGlobalTheme(configuration);
-        const { from } = createLocalTheme({
-          globalThemeContext,
-          factory ({ globalTheme, variant }) {
+        const { GlobalThemeProvider, createLocalTheme } = createGlobalTheme(configuration);
+        const { from } = createLocalTheme(
+          ({ globalTheme, variant }) => {
             const { brandColor, background, space } = globalTheme;
             let { color } = globalTheme;
 
@@ -353,7 +345,7 @@ suite('Component tests', (): void => {
               padding: space
             };
           }
-        });
+        );
 
         const Banner = styled.div`
           color: ${from(theme => theme.color)};


### PR DESCRIPTION
BREAKING CHANGE: `createLocalTheme` is not exported anymore and can be
obtained from `createGlobalTheme`.
BREAKING CHANGE: `createLocalTheme` only receives the factory now, you
don't need to pass the `globalThemeContext` anymore.
BREAKING CHANGE: `createGlobalTheme` does not return the
`globalThemeContext` anymore.